### PR TITLE
test: add rest of point and user test cases

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
   },
   "rules": {
     "quotes": ["error", "double"],
-    "semi": ["error", "never"]
+    "semi": ["error", "never"],
+    "no-underscore-dangle": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "cross-env NODE_ENV=production node ./bin/www",
     "predev": "npm run api-docs",
     "dev": "cross-env NODE_ENV=dev nodemon ./bin/www",
-    "test": "cross-env NODE_ENV=test jest --runInBand --watchAll"
+    "test": "cross-env NODE_ENV=test jest --watchAll"
   },
   "repository": {
     "type": "git",

--- a/services/point.service.js
+++ b/services/point.service.js
@@ -54,7 +54,8 @@ const create = async body => {
 }
 
 const update = async (id, body) => {
-  const res = await Point.updateOne({ _id: id }, body)
+  const res = await Point.findOneAndUpdate({ _id: id }, body, { new: true })
+
   if (!res) {
     return {
       code: statusCode.INTERNAL_SERVER_ERROR,
@@ -63,7 +64,7 @@ const update = async (id, body) => {
   }
   return {
     code: statusCode.OK,
-    json: authUtil.successTrue(responseMessage.X_UPDATE_SUCCESS("Point")),
+    json: authUtil.successTrue(responseMessage.X_UPDATE_SUCCESS("Point"), res),
   }
 }
 

--- a/services/user.service.js
+++ b/services/user.service.js
@@ -101,9 +101,10 @@ const updateUserInfo = async ({ id, userId, ...userInfo }) => {
       json: authUtil.successFalse(responseMessage.UNAUTHORIZED),
     }
   }
+
   // const getUserInfoResult = await User.findOne({ _id: id })
   // const updateUserInfoResult = await getUserInfoResult.updateOne(userInfo)
-  const updateUserInfoResult = await User.findOneAndUpdate({ _id: id }, userInfo)
+  const updateUserInfoResult = await User.findOneAndUpdate({ _id: id }, userInfo, { new: true })
 
   return {
     code: statusCode.OK,

--- a/tests/dbManager.js
+++ b/tests/dbManager.js
@@ -10,9 +10,7 @@ const connect = async () => {
 
   await mongoose.connect(uri, {
     useNewUrlParser: true,
-    autoReconnect: true,
-    reconnectTries: Number.MAX_VALUE,
-    reconnectInterval: 1000,
+    useUnifiedTopology: true,
   })
 }
 

--- a/tests/point.test.js
+++ b/tests/point.test.js
@@ -57,3 +57,12 @@ describe("PUT /points/:id", () => {
     expect(res.body.data.placeName).toEqual("changed")
   })
 })
+
+describe("DELETE /points/:id", () => {
+  test("success", async () => {
+    const res = await request(app).delete(`/points/${data.point._id}`).set("token", data.token)
+
+    expect(res.status).toBe(200)
+    expect(res.body.success).toEqual(true)
+  })
+})

--- a/tests/point.test.js
+++ b/tests/point.test.js
@@ -27,7 +27,7 @@ describe("POST /points", () => {
       longitude: "126.974800",
       elapsedTime: 30000,
     }
-    const res = await request(app).post("/points").set("token", data.token).send(body).expect(201)
+    const res = await request(app).post("/points").set("token", data.token).send(body)
 
     expect(res.status).toBe(201)
     expect(res.body.success).toEqual(true)
@@ -36,7 +36,7 @@ describe("POST /points", () => {
 
 describe("GET /points", () => {
   test("success", async () => {
-    const res = await request(app).get("/points").set("token", data.token).expect(200)
+    const res = await request(app).get("/points").set("token", data.token)
 
     expect(res.status).toBe(200)
     expect(res.body.success).toEqual(true)

--- a/tests/point.test.js
+++ b/tests/point.test.js
@@ -38,7 +38,7 @@ describe("GET /points", () => {
   test("success", async () => {
     const res = await request(app).get("/points").set("token", data.token)
 
-    data.point = res.body.data[0]
+    ;[data.point] = res.body.data
 
     expect(res.status).toBe(200)
     expect(res.body.success).toEqual(true)

--- a/tests/point.test.js
+++ b/tests/point.test.js
@@ -38,7 +38,22 @@ describe("GET /points", () => {
   test("success", async () => {
     const res = await request(app).get("/points").set("token", data.token)
 
+    data.point = res.body.data[0]
+
     expect(res.status).toBe(200)
     expect(res.body.success).toEqual(true)
+  })
+})
+
+describe("PUT /points/:id", () => {
+  test("success - change placeName", async () => {
+    const res = await request(app)
+      .put(`/points/${data.point._id}`)
+      .set("token", data.token)
+      .send({ placeName: "changed" })
+
+    expect(res.status).toBe(200)
+    expect(res.body.success).toEqual(true)
+    expect(res.body.data.placeName).toEqual("changed")
   })
 })

--- a/tests/point.test.js
+++ b/tests/point.test.js
@@ -2,8 +2,21 @@ const request = require("supertest")
 const app = require("../app")
 const dbManager = require("./dbManager.js")
 
+let data = null
+
 afterAll(() => dbManager.close())
-beforeAll(() => dbManager.connect())
+beforeAll(async () => {
+  await dbManager.connect()
+
+  const body = {
+    email: "test@test.com",
+    password: "test",
+    nickname: "test",
+  }
+
+  const res = await request(app).post("/users/signup").send(body)
+  data = { user: res.body.data.signinUser, token: res.body.data.token }
+})
 // afterEach(() => dbManager.clear())
 
 describe("POST /points", () => {
@@ -14,33 +27,18 @@ describe("POST /points", () => {
       longitude: "126.974800",
       elapsedTime: 30000,
     }
-    const response = await request(app).post("/points").send(body).expect(201)
-    console.log(response.body)
+    const res = await request(app).post("/points").set("token", data.token).send(body).expect(201)
+
+    expect(res.status).toBe(201)
+    expect(res.body.success).toEqual(true)
   })
 })
 
 describe("GET /points", () => {
   test("success", async () => {
-    const response = await request(app).get("/points").expect(200)
-    console.log(response.body)
+    const res = await request(app).get("/points").set("token", data.token).expect(200)
+
+    expect(res.status).toBe(200)
+    expect(res.body.success).toEqual(true)
   })
 })
-
-/**
- * {
-      success: true,
-      message: 'Point 작성 성공',
-      data: {
-        _id: '60112e9d3b9ab628f50f6816',
-        userId: 'test',
-        latitude: '37.5078166',
-        longitude: '126.9529052',
-        elapsedTime: 30000,
-        address: '서울특별시 동작구 매봉로2가길 11',
-        createdAt: '2021-01-27T09:13:01.259Z',
-        updatedAt: '2021-01-27T09:13:01.259Z',
-        __v: 0
-      }
-    }
-
- */

--- a/tests/user.test.js
+++ b/tests/user.test.js
@@ -4,7 +4,6 @@ const dbManager = require("./dbManager.js")
 
 afterAll(() => dbManager.close())
 beforeAll(() => dbManager.connect())
-// afterEach(() => dbManager.clear())
 
 describe("POST /users/signup", () => {
   test("success", async () => {
@@ -13,10 +12,14 @@ describe("POST /users/signup", () => {
       password: "test",
       nickname: "test",
     }
-    const response = await request(app).post("/users/signup").send(body).expect(201)
-    console.log(response.body)
+    const res = await request(app).post("/users/signup").send(body)
+
+    expect(res.status).toBe(201)
+    expect(res.body.success).toEqual(true)
   })
 })
+
+let data = null
 
 describe("POST /users/login", () => {
   test("success", async () => {
@@ -24,7 +27,30 @@ describe("POST /users/login", () => {
       email: "test@test.com",
       password: "test",
     }
-    const response = await request(app).post("/users/login").send(body).expect(200)
-    console.log(response.body)
+    const res = await request(app).post("/users/login").send(body).expect(200)
+
+    data = { user: res.body.data.getUserInfoResult, token: res.body.data.token }
+
+    expect(res.status).toBe(200)
+    expect(res.body.success).toEqual(true)
+  })
+})
+
+describe("PUT /users/:id", () => {
+  test("success - change nickname", async () => {
+    const res = await request(app).put(`/users/${data.user._id}`).set("token", data.token).send({ nickname: "changed" })
+
+    expect(res.status).toBe(200)
+    expect(res.body.success).toEqual(true)
+    expect(res.body.data.nickname).toEqual("changed")
+  })
+})
+
+describe("GET /users/", () => {
+  test("success", async () => {
+    const res = await request(app).get("/users/").set("token", data.token)
+
+    expect(res.status).toBe(200)
+    expect(res.body.success).toEqual(true)
   })
 })

--- a/tests/user.test.js
+++ b/tests/user.test.js
@@ -27,7 +27,7 @@ describe("POST /users/login", () => {
       email: "test@test.com",
       password: "test",
     }
-    const res = await request(app).post("/users/login").send(body).expect(200)
+    const res = await request(app).post("/users/login").send(body)
 
     data = { user: res.body.data.getUserInfoResult, token: res.body.data.token }
 


### PR DESCRIPTION
### Add test
- PUT /users/:id
- GET /users
- PUT /points/:id
- DELETE /points/:id

### Changed
- `PUT /points/:id` 변경된 데이터 리턴
- `no-underscore-danger` rule 제거: `mongoDB`의 `_id` 컬럼으로 인해 underscore 사용 필요.
- jest `-runInband` 옵션 제거: `-w` 옵션과 같이 사용했을 때 콘솔에 순서가 이상하게 찍힘. 특별히 이 옵션이 필요한 상황이 아니라 제거함